### PR TITLE
12 宿泊日/人数入力フォーム・予約リンクの作成

### DIFF
--- a/app/controllers/hotels_controller.rb
+++ b/app/controllers/hotels_controller.rb
@@ -59,8 +59,8 @@ class HotelsController < ApplicationController
       infant_with_m = params[:reservation][:infant_with_m]
       infant_with_b = params[:reservation][:infant_with_b] 
       infant_without_mb = params[:reservation][:infant_witout_mb]
-    end    
-    @room_info = check_vacant_rooms(hotel_no, checkin_date, checkout_date, adult_num, infant_with_mb,infant_with_m, infant_with_b, infant_without_mb)
+      @room_info = check_vacant_rooms(hotel_no, checkin_date, checkout_date, adult_num, infant_with_mb,infant_with_m, infant_with_b, infant_without_mb)
+    end 
   end
 
     private

--- a/app/controllers/hotels_controller.rb
+++ b/app/controllers/hotels_controller.rb
@@ -49,6 +49,18 @@ class HotelsController < ApplicationController
     @hotel = Hotel.find(params[:id])
     @hotel_api = fetch_hotel_api(@hotel.name)
     @reviews = @hotel.reviews
+    hotel_no = fetch_hotel_no(@hotel.name)
+    # フォームからのデータを取得
+    if params[:reservation]
+      checkin_date = params[:reservation][:checkin_date] # YYYY-MM-DD形式
+      checkout_date = params[:reservation][:checkout_date] # YYYY-MM-DD形式
+      adult_num = params[:reservation][:adult_num]
+      infant_with_mb = params[:reservation][:infant_with_mb]
+      infant_with_m = params[:reservation][:infant_with_m]
+      infant_with_b = params[:reservation][:infant_with_b] 
+      infant_without_mb = params[:reservation][:infant_witout_mb]
+    end    
+    @room_info = check_vacant_rooms(hotel_no, checkin_date, checkout_date, adult_num, infant_with_mb,infant_with_m, infant_with_b, infant_without_mb)
   end
 
     private
@@ -76,7 +88,30 @@ class HotelsController < ApplicationController
       
   }
     else
+      {}
+    end
+  end
+
+  def fetch_hotel_no(hotel_name)
+    encoded_name = URI.encode_www_form_component(hotel_name)
+    hotel_no_url = "https://app.rakuten.co.jp/services/api/Travel/KeywordHotelSearch/20170426?format=json&hotelThumbnailSize=1&elements=hotelNo&formatVersion=2&searchField=1&responseType=large&keyword=#{encoded_name}&applicationId=#{ENV['id']}"
+    uri = URI.parse(hotel_no_url)
+    response = Net::HTTP.get_response(uri)
+    detail = JSON.parse(response.body)
+  
+    if detail && detail["hotels"] && detail["hotels"][0] && detail["hotels"][0][0] && detail["hotels"][0][0]["hotelBasicInfo"]
+      return detail["hotels"][0][0]["hotelBasicInfo"]["hotelNo"]
+    else
       nil
     end
+  end
+  
+  def check_vacant_rooms(hotel_no, checkin_date, checkout_date, adult_num, infant_with_mb,infant_with_m, infant_with_b, infant_without_mb)
+    vacant_url = "https://app.rakuten.co.jp/services/api/Travel/VacantHotelSearch/20170426?format=json&elements=roomName,planName,withDinnerFlag,dinnerSelectFlag,breakfastSelectFlag,payment,reserveUrl,stayDate,rakutenCharge,total&checkinDate=#{checkin_date}&checkoutDate=#{checkout_date}&adultNum=#{adult_num}&infantWithMBNum=#{infant_with_mb}&infantWithMNum=#{infant_with_m}&infantWithBNum=#{infant_with_b}&infantWithoutMBNum=#{infant_without_mb}&hotelNo=#{hotel_no}&applicationId=#{ENV['id']}" 
+    uri = URI.parse(vacant_url)
+    response = Net::HTTP.get_response(uri)
+    room_info = JSON.parse(response.body)
+    @room_info = room_info
+    return @room_info
   end
 end

--- a/app/views/hotels/show.html.erb
+++ b/app/views/hotels/show.html.erb
@@ -13,7 +13,37 @@
         </div>
           <blockquote> <%= review.review %> </blockquote>
       <% end %>
-  <div>
-<% else %>
-  <p>ホテルの情報が見つかりませんでした。</p>
-<% end %>
+    
+  <%= form_with scope: :reservation, method: :get, local: false do |f| %>
+    <%= f.label :checkin_date, "チェックイン日" %>
+    <%= f.date_field :checkin_date, value: Date.today+30.days %>
+    <%= f.label :checkout_date, "チェックアウト日" %>
+    <%= f.date_field :checkout_date, value: Date.tomorrow+30.days %>
+    <%= f.label :adult_num, "人数（大人）" %>
+    <%= f.number_field :adult_num, type: :number, value: 2 %>
+    <%= f.label :infant_with_mb, "人数(幼児(食事・布団付))" %>
+    <%= f.number_field :infant_with_mb, type: :number, value: 0%>
+    <%= f.label :infant_with_m, "人数(幼児(食事のみ))" %>
+    <%= f.number_field :infant_with_m, type: :number, value: 0 %>
+    <%= f.label :infant_with_b, "人数(幼児(布団のみ))" %>
+    <%= f.number_field :infant_with_b, type: :number, value: 0 %>
+    <%= f.label :infant_without_mb, "人数(幼児(食事・布団なし))" %>
+    <%= f.number_field :infant_without_mb, type: :number, value: 0 %>
+    <%= f.submit "日付/人数を決定", data: { turbo: true, turbo_frame: "rooms-list" } %>
+  <% end %> 
+
+  <%= turbo_frame_tag "rooms-list" do %>
+    <% @room_info["hotels"].each do |hotel| %>
+      <% hotel["hotel"].each do |room_info| %>
+        <% room_info["roomInfo"].each do |room| %>
+          <h3>部屋名: <%= room["roomBasicInfo"]&.dig("roomName") %></h3>
+          <p>プラン名: <%= room["roomBasicInfo"]&.dig("planName") %></p>
+          <p>夕食: <%= room["roomBasicInfo"]&.dig("withDinnerFlag") == 0 ? "なし" : "あり" %></p>
+          <p>宿泊日: <%= room["dailyCharge"]&.dig("stayDate") %></p>
+          <p>宿泊料金: <%= room["dailyCharge"]&.dig("total") %>円</p>
+          <p>予約URL: <a href= "<%= room["roomBasicInfo"]&.dig("reserveUrl") %> "target="_blank">楽天トラベル予約リンク </a>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %> 

--- a/app/views/hotels/show.html.erb
+++ b/app/views/hotels/show.html.erb
@@ -1,49 +1,80 @@
 <% if @hotel_api %>
   <div class="card-body">
     <h2 class="card-title"><%= @hotel_api[:hotel_name] %></h2>
-      <%= @hotel_api[:hotel_special] %>
+      <div class="text-xs"><%= @hotel_api[:hotel_special] %></div>
       <strong>住所:</strong> <%= @hotel_api[:address1] %> <%= @hotel_api[:address2] %><br>
-      <img src="<%= @hotel_api[:hotel_image] %>"><img src="<%= @hotel_api[:room_image] %>"><br>      
-      <strong>料金:</strong> <%= @hotel_api[:min_charge] %>円〜<br>
-      <strong>口コミ</strong> 平均 <%= @hotel_api[:review_average] %>【口コミ数 全<%= @hotel_api[:review_count] %>件】
+      <div class="flex justify-center">
+        <div><img src="<%= @hotel_api[:hotel_image] %>"></div><br>
+        <div> <img src="<%= @hotel_api[:room_image] %>"></div>
+      </div>
+      <strong>料金:</strong> <%= @hotel_api[:min_charge] %>円〜<br> 
+      <div class="rating rating-sm">
+      <strong>口コミ</strong> 平均 <%= @hotel_api[:review_average] %>
+        <% 5.times do |i| %>
+          <% if i < @hotel_api[:review_average].to_i %>
+            <svg class="h-5 w-5 text-orange-400" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.37 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.176 0l-2.8 2.034c-.785.57-1.84-.197-1.54-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.049 8.719c-.782-.57-.38-1.81.588-1.81h3.462a1 1 0 00.95-.69l1.07-3.292z"/></svg>
+          <% else %>
+            <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.37 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.176 0l-2.8 2.034c-.785.57-1.84-.197-1.54-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.049 8.719c-.782-.57-.38-1.81.588-1.81h3.462a1 1 0 00.95-.69l1.07-3.292z"/></svg>
+          <% end %>
+        <% end %>
+        【口コミ数 全<%= @hotel_api[:review_count] %>件】
+      </div>
 
       <% @reviews.each do |review| %>
         <div> <%= review.review_user %> <%= review.review_time %> 
-          <a href="<%= review.url%>" target="_blank">引用元：楽天トラベルお客さまの声</a> 
+        <a href="<%= review.url%>" class="link link-info" target="_blank">引用元：楽天トラベルお客さまの声</a>
         </div>
           <blockquote> <%= review.review %> </blockquote>
       <% end %>
-    
-  <%= form_with scope: :reservation, method: :get, local: false do |f| %>
-    <%= f.label :checkin_date, "チェックイン日" %>
-    <%= f.date_field :checkin_date, value: Date.today+30.days %>
-    <%= f.label :checkout_date, "チェックアウト日" %>
-    <%= f.date_field :checkout_date, value: Date.tomorrow+30.days %>
-    <%= f.label :adult_num, "人数（大人）" %>
-    <%= f.number_field :adult_num, type: :number, value: 2 %>
-    <%= f.label :infant_with_mb, "人数(幼児(食事・布団付))" %>
-    <%= f.number_field :infant_with_mb, type: :number, value: 0%>
-    <%= f.label :infant_with_m, "人数(幼児(食事のみ))" %>
-    <%= f.number_field :infant_with_m, type: :number, value: 0 %>
-    <%= f.label :infant_with_b, "人数(幼児(布団のみ))" %>
-    <%= f.number_field :infant_with_b, type: :number, value: 0 %>
-    <%= f.label :infant_without_mb, "人数(幼児(食事・布団なし))" %>
-    <%= f.number_field :infant_without_mb, type: :number, value: 0 %>
-    <%= f.submit "日付/人数を決定", data: { turbo: true, turbo_frame: "rooms-list" } %>
-  <% end %> 
-
-  <%= turbo_frame_tag "rooms-list" do %>
-    <% @room_info["hotels"].each do |hotel| %>
-      <% hotel["hotel"].each do |room_info| %>
-        <% room_info["roomInfo"].each do |room| %>
-          <h3>部屋名: <%= room["roomBasicInfo"]&.dig("roomName") %></h3>
-          <p>プラン名: <%= room["roomBasicInfo"]&.dig("planName") %></p>
-          <p>夕食: <%= room["roomBasicInfo"]&.dig("withDinnerFlag") == 0 ? "なし" : "あり" %></p>
-          <p>宿泊日: <%= room["dailyCharge"]&.dig("stayDate") %></p>
-          <p>宿泊料金: <%= room["dailyCharge"]&.dig("total") %>円</p>
-          <p>予約URL: <a href= "<%= room["roomBasicInfo"]&.dig("reserveUrl") %> "target="_blank">楽天トラベル予約リンク </a>
-        <% end %>
-      <% end %>
+<div class="divider divider-">予約フォーム</div>
+  <div class="flex justify-center">
+    <%= form_with scope: :reservation, method: :get, local: false do |f| %>
+      <%= f.label :checkin_date, "チェックイン日" %>
+      <%= f.date_field :checkin_date, value: Date.today + 30.days %><br>
+      <%= f.label :checkout_date, "チェックアウト日" %>
+      <%= f.date_field :checkout_date, value: Date.tomorrow + 31.days %><br>
+      <%= f.label :adult_num, "人数（大人）" %>
+      <%= f.number_field :adult_num, type: :number, value: 2 %><br>
+      <%= f.label :infant_with_mb, "人数(幼児(食事・布団付))" %>
+      <%= f.number_field :infant_with_mb, type: :number, value: 0%><br>
+      <%= f.label :infant_with_m, "人数(幼児(食事のみ))" %>
+      <%= f.number_field :infant_with_m, type: :number, value: 0 %><br>
+      <%= f.label :infant_with_b, "人数(幼児(布団のみ))" %>
+      <%= f.number_field :infant_with_b, type: :number, value: 0 %><br>
+      <%= f.label :infant_without_mb, "人数(幼児(食事・布団なし))" %>
+      <%= f.number_field :infant_without_mb, type: :number, value: 0 %><br>
+      <button class="btn btn-secondary"><%= f.submit "日付/人数を決定", data: { turbo: true, turbo_frame: "rooms-list" } %></button>
     <% end %>
-  <% end %>
+
+    <div class="card w-96 bg-primary shadow-xl" >  
+      <% if @room_info && @room_info["hotels"].present? %>
+        <%= turbo_frame_tag "rooms-list" do %>
+          <% @room_info["hotels"].each do |hotel| %>
+            <% hotel["hotel"].each do |h| %>
+              <% h["roomInfo"].each do |info| %>
+              <!-- roomBasicInfoの表示 -->
+                <br>
+                <% if info["roomBasicInfo"].present? %>
+                  <div class="font-bold">プラン名: <%= info["roomBasicInfo"]["planName"] %></div>
+                  <p>部屋名: <%= info["roomBasicInfo"]["roomName"] %></p>
+                  <p>夕食: <%= info["roomBasicInfo"]["withDinnerFlag"] == 1 ? "あり" : "なし" %></p>
+                  <p>朝食: <%= info["roomBasicInfo"]["withBreakfastFlag"] == 1 ? "あり" : "なし" %></p>
+                  <%= link_to '予約リンク（→楽天トラベルサイト）', info["roomBasicInfo"]["reserveUrl"], class: "link link-info" %>
+                <% end %>
+                <!-- dailyChargeの表示 -->
+                <% if info["dailyCharge"].present? %>
+                  <p>宿泊日: <%= info["dailyCharge"]["stayDate"] %></p>
+                  <p>合計料金: <%= info["dailyCharge"]["total"] %>円</p>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% else %>
+        <%= " " %>
+      <% end %>
+    </div>
+  </div>
 <% end %> 
+    </div>
+  </div> 


### PR DESCRIPTION
以下の内容を実施しました。
## 実装内容
- [x] 宿泊日/人数入力フォームの作成
楽天トラベル施設情報API でhotel_noを取得した上で（fetch_hotel_no）、楽天トラベル空室情報APIでhotel_noを使い、宿泊日・人数の情報を入力し、検索できるように実装（check_vacant_rooms）。
- [x] 予約リンク作成
フォームに入力した情報から楽天トラベル空室情報APIの予約リンクを表示。
- [x] レイアウトの調整
詳細画面について、文字の大きさ、画像の表示場所、ratingの星の数の表示。
## 確認方法
詳細画面へ遷移すると予約入力フォームが表示され、数値入力後、決定ボタンを押すと宿泊プランと予約リンクなどが表示される。

Closes #19 